### PR TITLE
This commit has fixes for path partsing and it uses the root for temp files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automerge_repo"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [[example]]


### PR DESCRIPTION
I think it should at least be configurable where to store the temp files, but the same root as the data directory is safer, as you can't `rename` files across filesystem types in the way spanreed is doing so now.

I am also seeing filenames like this:

```
./259d/63393439333239642d366630662d346437612d613138312d636435323632386165626163/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.incremental
```

Which has 72 characters for the doc id and 64 for the hash. I haven't dug into why yet.

The loading function was also not previously working. The implementation is now functional, if not entirely correct. 