### PR TITLE
Fix minor test bug.

### DIFF
--- a/src/fs_store.rs
+++ b/src/fs_store.rs
@@ -86,7 +86,7 @@ impl FsStore {
     pub fn get(&self, id: &DocumentId) -> Result<Option<Vec<u8>>, Error> {
         let chunks = Chunks::load(&self.root, id)?;
         let Some(chunks) = chunks else {
-            return Ok(None)
+            return Ok(None);
         };
         let mut result = Vec::new();
         result.extend(chunks.snapshots.into_values().flatten());
@@ -163,7 +163,7 @@ impl FsStore {
         // Load all the data we have into a doc
         let Some(chunks) = Chunks::load(&self.root, id)? else {
             tracing::warn!(doc_id=%id, "attempted to compact non-existent document");
-            return Ok(())
+            return Ok(());
         };
         let mut doc = chunks
             .to_doc()
@@ -382,7 +382,8 @@ impl Chunks {
                 tracing::warn!(bad_file=%path.display(), "unexpected non-file in level2 path");
                 continue;
             }
-            let Some(chunk_name) = entry.file_name().to_str().and_then(SavedChunkName::parse) else {
+            let Some(chunk_name) = entry.file_name().to_str().and_then(SavedChunkName::parse)
+            else {
                 tracing::warn!(bad_file=%path.display(), "unexpected non-chunk file in level2 path");
                 continue;
             };

--- a/test_utils/src/storage_utils.rs
+++ b/test_utils/src/storage_utils.rs
@@ -136,8 +136,8 @@ impl AsyncInMemoryStorage {
                     StorageRequest::Compact(doc_id, data, sender) => {
                         let _entry = documents
                             .entry(doc_id)
-                            .and_modify(|entry| *entry = data)
-                            .or_insert_with(Default::default);
+                            .and_modify(|entry| *entry = data.clone())
+                            .or_insert_with(|| data);
                         let (tx, rx) = oneshot();
                         results.push_back(tx);
                         tokio::spawn(async move {


### PR DESCRIPTION
AsyncInMemoryStorage has a bug in compaction where the first entry is not able to be compacted.

This would not normally be caught, but there's a bug in repo.rs where compaction doesn't happen, and I'm trying to track that down.